### PR TITLE
Server create bot function

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,10 @@ const events = require('events')
 registerTest('run forward', async (server, startPosition) => {
 
   // Create your bot and have it join the server
-  const bot = mineflayer.createBot({
-    host: 'localhost',
-    port: server.port,
-    username: 'bot123456'
+  const bot = await server.createBot({
+    makeOp: true,
+    startPosition: startPosition
   })
-
-  // Wait for the bot to spawn
-  await events.once(bot, 'spawn')
-
-  // Make the bot op and teleport them to the start position
-  await server.makeOp(bot)
-  await server.teleport(bot, startPosition)
 
   // Run our test
   bot.setControlState('sprint', true)

--- a/examples/example-repo/test/exampleTest.js
+++ b/examples/example-repo/test/exampleTest.js
@@ -1,17 +1,10 @@
 const { registerTest } = require('mineflayer-test-api')
-const mineflayer = require('mineflayer')
-const events = require('events')
 
 registerTest('run forward', async (server, startPosition) => {
-  const bot = mineflayer.createBot({
-    host: 'localhost',
-    port: server.port,
-    username: 'bot123456'
+  const bot = await server.createBot({
+    makeOp: true,
+    startPosition: startPosition
   })
-
-  await events.once(bot, 'spawn')
-  await server.makeOp(bot)
-  await server.teleport(bot, startPosition)
 
   bot.setControlState('sprint', true)
   bot.setControlState('forward', true)

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "minecraft-data": "^2.81.0",
     "minecraft-protocol": "^1.24.2",
     "minecraft-wrap": "^1.3.0",
+    "mineflayer": "^4.3.0",
     "path": "^0.12.7",
+    "uuid": "^8.3.2",
     "vec3": "^0.1.7"
   }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -3,6 +3,9 @@ const mc = require('minecraft-protocol')
 const path = require('path')
 const assert = require('assert')
 const { once } = require('events')
+const mineflayer = require('mineflayer')
+const { v4: uuidv4 } = require('uuid')
+const events = require('events')
 
 async function sleep (time) {
   await new Promise(resolve => setTimeout(resolve, time))
@@ -99,6 +102,21 @@ async function startServer (options) {
         }
       })
     })
+  }
+
+  server.createBot = async function (botOptions = {}) {
+    const bot = mineflayer.createBot({
+      host: 'localhost',
+      port: server.port,
+      username: uuidv4().substring(0, 15),
+      version: server.version
+    })
+
+    await events.once(bot, 'spawn')
+    if (botOptions.makeOp) await server.makeOp(bot)
+    if (botOptions.startPosition) await server.teleport(bot, botOptions.startPosition)
+
+    return bot
   }
 
   server.makeOp = async function (bot) {


### PR DESCRIPTION
I figured it would reduce test boilerplate code to have a built-in createBot function on the server, to automatically handle bot creation, joining the server, teleporting to the correct location, and so on. This should make tests a bit easier to read and maintain.